### PR TITLE
Fix: Configure CORS and session cookies for API auth

### DIFF
--- a/client/src/lib/fetchWithAuth.ts
+++ b/client/src/lib/fetchWithAuth.ts
@@ -1,0 +1,10 @@
+// src/lib/fetchWithAuth.ts
+export const fetchWithAuth = (url: string, options: RequestInit = {}) =>
+  fetch(url, {
+    ...options,
+    credentials: 'include', // 👈 Ensures session cookies are sent
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
+        "cors": "^2.8.5",
         "cron-validator": "^1.3.1",
         "date-fns": "^3.6.0",
         "drizzle-orm": "^0.39.1",
@@ -5291,6 +5292,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cron-validator": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
+    "cors": "^2.8.5",
     "cron-validator": "^1.3.1",
     "date-fns": "^3.6.0",
     "drizzle-orm": "^0.39.1",

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
 import connectPgSimple from "connect-pg-simple";
 import dotenv from "dotenv";
+import cors from "cors";
 import { pool } from "./db"; // Assuming db.ts exports 'pool' for connect-pg-simple
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
@@ -10,6 +11,15 @@ import { setupMemoryOptimization } from "./middleware/memoryOptimization";
 dotenv.config();
 
 const app = express();
+
+// CORS middleware - place before session and routes
+app.use(
+  cors({
+    origin: "https://pitasker.piapps.dev",
+    credentials: true,
+  }),
+);
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
@@ -29,6 +39,7 @@ app.use(
       secure: process.env.NODE_ENV === "production", // True if using https
       httpOnly: true,
       maxAge: 1000 * 60 * 60 * 24 * 7, // 1 week
+      sameSite: "lax", // Added for cross-site cookie sending
     },
   }),
 );


### PR DESCRIPTION
- Added `cors` middleware to allow credentials from the frontend origin.
- Updated session cookie settings (`sameSite: 'lax'`) to ensure cookies are sent with cross-origin requests.
- Created `fetchWithAuth.ts` helper, though existing API functions already included credentials.
- Ensured `cookie.secure` is true in production for HTTPS.