### PR TITLE
Fix build integration and session store

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,13 @@
 import express from 'express';
 import cors from 'cors';
 import session from 'express-session';
+import connectPgSimple from 'connect-pg-simple';
 import dotenv from 'dotenv';
 import path from 'path';
+import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { registerRoutes } from './routes';
+import { pool } from './db';
 
 dotenv.config();
 
@@ -30,9 +33,11 @@ app.use(
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// Session middleware
+// Session middleware (PostgreSQL store)
+const PgSession = connectPgSimple(session);
 app.use(
   session({
+    store: new PgSession({ pool }),
     name: 'pitasker.sid',
     secret: process.env.SESSION_SECRET || 'replace_this_with_a_strong_secret',
     resave: false,
@@ -50,13 +55,23 @@ const startServer = async () => {
   // Register backend routes
   await registerRoutes(app);
 
-  // Serve static frontend (assumes Create React App)
-  const clientBuildPath = path.join(__dirname, '..', 'client', 'build');
-  app.use(express.static(clientBuildPath));
-
-  app.get('*', (req, res) => {
-    res.sendFile(path.join(clientBuildPath, 'index.html'));
-  });
+  // Serve static frontend (works with Vite or CRA build)
+  const candidateDirs = [
+    path.join(__dirname, 'public'),
+    path.join(__dirname, '..', 'client', 'dist'),
+    path.join(__dirname, '..', 'client', 'build'),
+  ];
+  const staticDir = candidateDirs.find((dir) =>
+    fs.existsSync(path.join(dir, 'index.html')),
+  );
+  if (staticDir) {
+    app.use(express.static(staticDir));
+    app.get('*', (_req, res) => {
+      res.sendFile(path.join(staticDir, 'index.html'));
+    });
+  } else {
+    console.warn('[server] No frontend build directory found.');
+  }
 
   const PORT = process.env.PORT || 5007;
   app.listen(PORT, () => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,4 @@
 import type { Express, Request, Response } from "express";
-import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { findUserByUsername, findUserById, comparePassword, updateUserPassword, hashPassword } from "./auth"; // Added findUserById
 import { isAuthenticated } from "./middleware/authMiddleware";
@@ -19,7 +18,7 @@ const taskScheduler = new TaskScheduler();
 const taskRunner = new TaskRunner();
 const notificationService = new NotificationService();
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export async function registerRoutes(app: Express): Promise<void> {
   // Enhanced health check endpoint with uptime
   app.get("/health", (req, res) => {
     const uptime = process.uptime() * 1000; // Convert to milliseconds
@@ -306,7 +305,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Initialize tasks on startup
   initializeTasks();
-
-  const httpServer = createServer(app);
-  return httpServer;
 }


### PR DESCRIPTION
## Summary
- reconnect Express session storage using `connect-pg-simple`
- autodetect frontend build directory when serving static files
- simplify `registerRoutes` to no longer create its own HTTP server

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a92f108e883229693c3cbbff032c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved static frontend serving to support multiple build directories, enhancing compatibility with different frontend setups (e.g., Vite, Create React App).
* **Chores**
  * Switched session storage to use a PostgreSQL-backed store for improved reliability.
* **Refactor**
  * Updated internal route registration logic, with no impact on user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->