### PR TITLE
Add Edit Task modal

### DIFF
--- a/client/src/components/EditTaskModal.tsx
+++ b/client/src/components/EditTaskModal.tsx
@@ -1,0 +1,145 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { updateTaskSchema, type UpdateTask, type Task } from "@shared/schema";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+
+interface EditTaskModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  task: Task | null;
+}
+
+export default function EditTaskModal({ isOpen, onClose, task }: EditTaskModalProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const form = useForm<UpdateTask>({
+    resolver: zodResolver(updateTaskSchema),
+    defaultValues: {
+      name: task?.name ?? "",
+      cronSchedule: task?.cronSchedule ?? "",
+      command: task?.command ?? "",
+    },
+  });
+
+  useEffect(() => {
+    if (task) {
+      form.reset({
+        name: task.name,
+        cronSchedule: task.cronSchedule,
+        command: task.command,
+      });
+    }
+  }, [task, form]);
+
+  const updateMutation = useMutation({
+    mutationFn: async (data: UpdateTask) => {
+      const res = await apiRequest("PATCH", `/api/tasks/${task!.id}`, data);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/tasks/stats"] });
+      toast({ title: "Task Updated", description: "The task was updated successfully." });
+      onClose();
+    },
+    onError: (err: any) => {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to update task",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: UpdateTask) => {
+    updateMutation.mutate(data);
+  };
+
+  if (!task) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+        <DialogHeader>
+          <DialogTitle>Edit Task</DialogTitle>
+          <DialogDescription>Modify the task details below.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-gray-700 dark:text-gray-300">Task Name</FormLabel>
+                  <FormControl>
+                    <Input className="bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="cronSchedule"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-gray-700 dark:text-gray-300">Cron Schedule</FormLabel>
+                  <FormControl>
+                    <Input className="bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white font-mono" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="command"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-gray-700 dark:text-gray-300">Shell Command</FormLabel>
+                  <FormControl>
+                    <Textarea rows={3} className="bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white font-mono" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter className="flex gap-2">
+              <DialogClose asChild>
+                <Button variant="secondary" type="button">Cancel</Button>
+              </DialogClose>
+              <Button type="submit" disabled={updateMutation.isPending}>
+                {updateMutation.isPending ? "Saving..." : "Save Changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/TaskList.tsx
+++ b/client/src/components/TaskList.tsx
@@ -9,6 +9,7 @@ import { useTasks } from "@/hooks/useTasks";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import ConfirmationModal from "@/components/ConfirmationModal";
+import EditTaskModal from "@/components/EditTaskModal";
 import type { Task } from "@shared/schema";
 
 const getStatusBadge = (status: string) => {
@@ -90,6 +91,8 @@ export default function TaskList() {
     task: null,
     action: 'run'
   });
+  const [editTask, setEditTask] = useState<Task | null>(null);
+  const [isEditOpen, setIsEditOpen] = useState(false);
   
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -152,6 +155,11 @@ export default function TaskList() {
 
   const handleDeleteTask = (task: Task) => {
     setConfirmModal({ isOpen: true, task, action: 'delete' });
+  };
+
+  const handleEditTask = (task: Task) => {
+    setEditTask(task);
+    setIsEditOpen(true);
   };
 
   const handleConfirmAction = () => {
@@ -253,6 +261,7 @@ export default function TaskList() {
                           <Button
                             variant="ghost"
                             size="sm"
+                            onClick={() => handleEditTask(task)}
                             className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300"
                           >
                             <Edit className="h-4 w-4" />
@@ -283,6 +292,11 @@ export default function TaskList() {
         task={confirmModal.task}
         action={confirmModal.action}
         isLoading={runTaskMutation.isPending || deleteTaskMutation.isPending}
+      />
+      <EditTaskModal
+        isOpen={isEditOpen}
+        onClose={() => { setIsEditOpen(false); setEditTask(null); }}
+        task={editTask}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- add EditTaskModal component for editing tasks
- hook edit modal into task list UI
- open modal when clicking Edit and refresh tasks on save

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686b668e5d288322983133f8207b891a