### PR TITLE
Implement cron task export API

### DIFF
--- a/client/src/components/QuickActions.tsx
+++ b/client/src/components/QuickActions.tsx
@@ -29,11 +29,32 @@ export default function QuickActions() {
     });
   };
 
-  const handleExport = () => {
-    toast({
-      title: "Feature Coming Soon", 
-      description: "Export tasks functionality will be available in a future update.",
-    });
+  const handleExport = async () => {
+    try {
+      const res = await fetch('/api/tasks/export', { credentials: 'include' });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'pitasker-tasks.json';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+      toast({
+        title: 'Exported',
+        description: 'Tasks have been downloaded.'
+      });
+    } catch (err: any) {
+      toast({
+        title: 'Error',
+        description: err.message || 'Failed to export tasks',
+        variant: 'destructive',
+      });
+    }
   };
 
   const handleRefresh = () => {


### PR DESCRIPTION
## Summary
- add endpoint to export all tasks as JSON
- allow dashboard to download exported tasks

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686bc7c1653c8322a62060cc582ba16c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to export all tasks as a downloadable JSON file from the Quick Actions menu.
  * Exported tasks include relevant details and can be formatted for readability with an optional setting.
  * Users receive clear notifications for both successful downloads and any errors encountered during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->