### PR TITLE
Add About modal to PiTasker header

### DIFF
--- a/client/src/components/AboutModal.tsx
+++ b/client/src/components/AboutModal.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { InfoIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+
+export default function AboutModal() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <button
+              className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-md"
+              aria-label="About PiTasker"
+            >
+              <InfoIcon className="h-5 w-5" />
+            </button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>About PiTasker</TooltipContent>
+      </Tooltip>
+      <DialogContent className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+        <DialogHeader>
+          <DialogTitle>About PiTasker</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 text-sm text-gray-700 dark:text-gray-300">
+          <div>
+            <h3 className="font-medium">Tech Stack</h3>
+            <ul className="list-disc pl-4 space-y-1">
+              <li>Backend: Node.js, Express.js, TypeScript</li>
+              <li>Database: PostgreSQL + Drizzle ORM</li>
+              <li>Frontend: React 18, TypeScript, Vite</li>
+              <li>Styling: TailwindCSS, Shadcn/ui</li>
+              <li>State Management: TanStack Query</li>
+              <li>Routing: Wouter</li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-medium">Contact</h3>
+            <p>Author: 0xWulf</p>
+            <p>
+              Email: <a className="text-blue-600 hover:underline" href="mailto:dev@0xwulf.dev">dev@0xwulf.dev</a>
+            </p>
+          </div>
+          <div>
+            <h3 className="font-medium">GitHub Repo</h3>
+            <a
+              href="https://github.com/hexawulf/PiTasker"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              https://github.com/hexawulf/PiTasker
+            </a>
+          </div>
+          <p>
+            <strong>Version:</strong> v1.0.0
+          </p>
+          <p>
+            <strong>Release Date:</strong> July 2025
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -16,6 +16,7 @@ import TaskList from "@/components/TaskList";
 import QuickActions from "@/components/QuickActions";
 import ImportCronModal from "@/components/ImportCronModal";
 import SystemMonitor from "@/components/SystemMonitor";
+import AboutModal from "@/components/AboutModal";
 import { requestNotificationPermission, setupNotificationListener, showTaskNotification } from "@/lib/firebase";
 import { useToast } from "@/hooks/use-toast";
 import { useTasks } from "@/hooks/useTasks";
@@ -98,14 +99,15 @@ export default function Dashboard() {
                 </nav>
               </div>
             </div>
-            <div className="flex items-center space-x-4">
-              <div className="flex items-center space-x-2">
-                <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-                <span className="text-sm text-gray-600 dark:text-gray-300">Connected</span>
-              </div>
-              <button className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-md">
-                <Moon className="h-5 w-5" />
-              </button>
+              <div className="flex items-center space-x-4">
+                <div className="flex items-center space-x-2">
+                  <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
+                  <span className="text-sm text-gray-600 dark:text-gray-300">Connected</span>
+                </div>
+                <AboutModal />
+                <button className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-md">
+                  <Moon className="h-5 w-5" />
+                </button>
               <button className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-md relative">
                 <Bell className="h-5 w-5" />
                 <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full text-xs"></span>


### PR DESCRIPTION
## Summary
- add About modal component
- show About modal trigger in Dashboard header with tooltip

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686bd7845ed88322ae2a489a3143dc0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "About" modal accessible from the Dashboard header, providing information about the application, tech stack, contact details, GitHub link, and version details. The modal supports dark mode and enhanced accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->