### PR TITLE
Fix session expiry handling on task fetch

### DIFF
--- a/client/src/hooks/useTasks.ts
+++ b/client/src/hooks/useTasks.ts
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Task } from "@shared/schema";
+import { getQueryFn } from "@/lib/queryClient";
 
 export function useTasks() {
   return useQuery<Task[]>({
     queryKey: ["/api/tasks"],
+    queryFn: getQueryFn<Task[]>({ on401: "returnNull" }),
     refetchInterval: 5000, // Refresh every 5 seconds for real-time updates
   });
 }
@@ -11,6 +13,7 @@ export function useTasks() {
 export function useTask(id: number) {
   return useQuery<Task>({
     queryKey: ["/api/tasks", id],
+    queryFn: getQueryFn<Task>({ on401: "returnNull" }),
     enabled: !!id,
   });
 }

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,7 +1,20 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { toast } from "@/hooks/use-toast";
+
+function handleUnauthorized() {
+  toast({
+    title: "Session expired",
+    description: "Please log in again.",
+    variant: "destructive",
+  });
+  window.location.href = "/login";
+}
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
+    if (res.status === 401) {
+      handleUnauthorized();
+    }
     const text = (await res.text()) || res.statusText;
     throw new Error(`${res.status}: ${text}`);
   }
@@ -24,22 +37,21 @@ export async function apiRequest(
 }
 
 type UnauthorizedBehavior = "returnNull" | "throw";
-export const getQueryFn: <T>(options: {
-  on401: UnauthorizedBehavior;
-}) => QueryFunction<T> =
-  ({ on401: unauthorizedBehavior }) =>
-  async ({ queryKey }) => {
+export function getQueryFn<T>({ on401 }: { on401: UnauthorizedBehavior }): QueryFunction<T> {
+  return async ({ queryKey }) => {
     const res = await fetch(queryKey[0] as string, {
       credentials: "include",
     });
 
-    if (unauthorizedBehavior === "returnNull" && res.status === 401) {
-      return null;
+    if (on401 === "returnNull" && res.status === 401) {
+      handleUnauthorized();
+      return null as unknown as T;
     }
 
     await throwIfResNotOk(res);
     return await res.json();
   };
+}
 
 export const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary
- redirect and notify on 401 responses via `getQueryFn`
- use the new query function inside `useTasks`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686dcb8b09b883228d7d6df4475073da